### PR TITLE
Add fallback message for mobile & desktop notifications

### DIFF
--- a/src/sentry_slack/plugin.py
+++ b/src/sentry_slack/plugin.py
@@ -66,7 +66,6 @@ class SlackPlugin(notify.NotificationPlugin):
             escape(team.name.encode('utf-8')),
             escape(project.name.encode('utf-8')),
         )
-
         message = getattr(group, 'message_short', group.message).encode('utf-8')
         culprit = getattr(group, 'title', group.culprit).encode('utf-8')
 
@@ -75,10 +74,17 @@ class SlackPlugin(notify.NotificationPlugin):
         if message == culprit:
             culprit = ''
 
+        fallback_title = '[%s %s] %s' % (
+            escape(team.name.encode('utf-8')),
+            escape(project.name.encode('utf-8')),
+            message
+        )
+
         payload = {
             'parse': 'none',
-            'text': title,
             'attachments': [{
+                'pretext': title,
+                'fallback': fallback_title,
                 'color': self.color_for_group(group),
                 'fields': [{
                     'title': message,


### PR DESCRIPTION
Instead of `New event on {team} {project}` it is now `[{team} {project}] {event_message}`, so notifications are more meaningful and allow to see what event arrived without opening the app.

Regular message representation in slack is not changed

First notification is new style, second is old style 

![Notification iOS](http://f.cl.ly/items/3R1T0E0O3d1H3y3e083O/sentry-slack.png)
