### PR TITLE
Add ability to send to arbitrary rooms with rules

### DIFF
--- a/src/sentry_slack/actions.py
+++ b/src/sentry_slack/actions.py
@@ -8,8 +8,8 @@ from sentry.rules.actions.base import EventAction
 
 
 class NotifySlackRoomForm(forms.Form):
-    room = forms.TextField()
-    label = forms.TextField()
+    room = forms.CharField()
+    label = forms.CharField()
 
 
 class NotifySlackRoomAction(EventAction):

--- a/src/sentry_slack/actions.py
+++ b/src/sentry_slack/actions.py
@@ -27,7 +27,7 @@ class NotifySlackRoomAction(EventAction):
             return
 
         prefix = self.get_option('label') or 'Rule Triggered'
-        plugin.send_event_to_slack(event, prefix)
+        plugin.send_event_to_slack(event, prefix, room=room)
 
 
 rules.add(NotifySlackRoomAction)

--- a/src/sentry_slack/actions.py
+++ b/src/sentry_slack/actions.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 from django import forms
 
 from sentry.plugins import plugins
-from sentry.rules import rules
 from sentry.rules.actions.base import EventAction
 
 
@@ -27,7 +26,4 @@ class NotifySlackRoomAction(EventAction):
             return
 
         prefix = self.get_option('label') or 'Rule Triggered'
-        plugin.send_event_to_slack(event, prefix, room=room)
-
-
-rules.add(NotifySlackRoomAction)
+        yield self.future(plugin.send_event_to_slack, event=event, prefix=prefix, room=room)

--- a/src/sentry_slack/actions.py
+++ b/src/sentry_slack/actions.py
@@ -1,0 +1,33 @@
+from __future__ import absolute_import
+
+from django import forms
+
+from sentry.plugins import plugins
+from sentry.rules import rules
+from sentry.rules.actions.base import EventAction
+
+
+class NotifySlackRoomForm(forms.Form):
+    room = forms.TextField()
+    label = forms.TextField()
+
+
+class NotifySlackRoomAction(EventAction):
+    form_cls = NotifySlackRoomForm
+    label = 'Send a notification to a Slack {room} labeled {label}'
+
+    def after(self, event, state):
+        room = self.get_option('room')
+
+        if not room:
+            return
+
+        plugin = plugins.get('slack')
+        if not plugin.is_enabled(self.project):
+            return
+
+        prefix = self.get_option('label') or 'Rule Triggered'
+        plugin.send_event_to_slack(event, prefix)
+
+
+rules.add(NotifySlackRoomAction)

--- a/src/sentry_slack/plugin.py
+++ b/src/sentry_slack/plugin.py
@@ -56,14 +56,14 @@ class SlackPlugin(notify.NotificationPlugin):
     def webhook_for_project(self, project):
         return self.get_option('webhook', project)
 
-    def notify_users(self, group, event, fail_silently=False, room=None):
+    def notify_users(self, group, event, fail_silently=False):
         if not self.is_configured(group.project):
             return
 
         prefix = 'New event' if group.times_seen == 1 else 'Regression'
         self.send_event_to_slack(event, prefix)
 
-    def send_event_to_slack(self, event, prefix="Event"):
+    def send_event_to_slack(self, event, prefix="Event", room=None):
         webhook = self.webhook_for_project(event.project)
         project = event.project
         team = event.team
@@ -85,12 +85,12 @@ class SlackPlugin(notify.NotificationPlugin):
             culprit = ''
 
         color = self.color_for_group(group)
-        self.send_to_slack(webhook, text, title=message, value=culprit, color=color)
+        self.send_to_slack(webhook, text, title=message, value=culprit, color=color, room=room)
 
     def send_to_slack(self, webhook, text, title=None, value='', color="#f18500", room=None):
         payload = {
             'parse': 'none',
-            'text': title,
+            'text': text,
         }
         if title:
             payload['attachments'] = [{

--- a/src/sentry_slack/plugin.py
+++ b/src/sentry_slack/plugin.py
@@ -13,6 +13,8 @@ from sentry import http
 from sentry.plugins.bases import notify
 from sentry.utils import json
 
+from sentry_slack.actions import NotifySlackRoomAction
+
 import urllib
 
 LEVEL_TO_COLOR = {

--- a/src/sentry_slack/plugin.py
+++ b/src/sentry_slack/plugin.py
@@ -51,7 +51,7 @@ class SlackPlugin(notify.NotificationPlugin):
         return all((self.get_option(k, project) for k in ('webhook',)))
 
     def color_for_group(self, group):
-        return '#' + LEVEL_TO_COLOR.get(group.get_level_display(), 'error')
+        return '#' + LEVEL_TO_COLOR.get(group.get_level_display(), LEVEL_TO_COLOR['error'])
 
     def webhook_for_project(self, project):
         return self.get_option('webhook', project)

--- a/src/sentry_slack/plugin.py
+++ b/src/sentry_slack/plugin.py
@@ -10,12 +10,12 @@ import sentry_slack
 from django import forms
 
 from sentry import http
+from sentry.plugins.base import Plugin2
 from sentry.plugins.bases import notify
 from sentry.utils import json
 
 from sentry_slack.actions import NotifySlackRoomAction
 
-import urllib
 
 LEVEL_TO_COLOR = {
     'debug': 'cfd3da',
@@ -32,7 +32,7 @@ class SlackOptionsForm(notify.NotificationConfigurationForm):
         widget=forms.TextInput(attrs={'class': 'span8'}))
 
 
-class SlackPlugin(notify.NotificationPlugin):
+class SlackPlugin(Plugin2):
     author = 'Sentry Team'
     author_url = 'https://github.com/getsentry'
     resource_links = (
@@ -49,6 +49,9 @@ class SlackPlugin(notify.NotificationPlugin):
 
     def is_configured(self, project):
         return all((self.get_option(k, project) for k in ('webhook',)))
+
+    def get_rules(self, **kwargs):
+        return [NotifySlackRoomAction]
 
     def color_for_group(self, group):
         return '#' + LEVEL_TO_COLOR.get(group.get_level_display(), LEVEL_TO_COLOR['error'])


### PR DESCRIPTION
# Pros

Merging this will result in the creation of a new EventAction, to send a slack notification to a particular room:

![citools_settings___sentry](https://cloud.githubusercontent.com/assets/536102/7664784/6bdb17de-fb5e-11e4-8ce6-3889fe30664e.png)

Upon selecting it the user will get a form with 2 fields

![citools_settings___sentry](https://cloud.githubusercontent.com/assets/536102/7664788/05c86ab8-fb5f-11e4-8c59-4adc5bf00429.png)

From the above example, here is a notification in #infra-team after sending a test message with raven test:

![screenshot_5_16_15__12_02_am](https://cloud.githubusercontent.com/assets/536102/7664787/f4191240-fb5e-11e4-8cf5-0f815f988b7c.png)

It will send to a channel if it's prefixed with # or a user if prefixed with @, though there's not really a ton of flexibility in the rules forms right now to indicate that, so a possible improvement is to create 2 rules, one which validates and noramalizes to a username and another for channels.
# Cons

The rules API isn't really published or solidified, so this is way out there. Once this plugin is installed and activated in any project the rule will show in every project. 
