### PR TITLE
Prefer to install from PyPi rather than master

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,6 +10,6 @@ Install
 
 Install the package via ``pip``::
 
-    pip install https://github.com/getsentry/sentry-slack/archive/master.zip
+    pip install sentry-slack
 
 You can now configure webhooks via the plugin configuration panel within your project.


### PR DESCRIPTION
Hey Sentry team, and thanks for everything! I thought it'd be better to install from a stable version on PyPi rather than master, so I made this change to the README – what do you think?