### PR TITLE
Added ability to send events to different channels depending on the value of a tag

### DIFF
--- a/tests/sentry_slack/test_plugin.py
+++ b/tests/sentry_slack/test_plugin.py
@@ -59,3 +59,80 @@ class SlackPluginTest(TestCase):
             ],
         }
 
+    @responses.activate
+    def test_with_sorting(self):
+        responses.add('POST', 'http://example.com/slack')
+        self.plugin.set_option('webhook', 'http://example.com/slack', self.project)
+        self.plugin.set_option('sort_on_tag', True, self.project)
+        self.plugin.set_option('sort_on_tag_key', 'test_tag_key', self.project)
+        self.plugin.set_option('group_1_tag_values', 'a,b,c', self.project)
+        self.plugin.set_option('group_1_channel', '#test_channel', self.project)
+        self.plugin.set_option('group_2_tag_values', 'd,e,f', self.project)
+        self.plugin.set_option('group_3_tag_values', 'b', self.project)
+        self.plugin.set_option('group_3_channel', '#test_channel2', self.project)
+
+        group = self.create_group(message='Hello world', culprit='foo.bar')
+        event = self.create_event(group=group, message='Hello world', tags={'test_tag_key': 'b'})
+
+        rule = Rule.objects.create(project=self.project, label='my rule')
+
+        notification = Notification(event=event, rule=rule)
+
+        with self.options({'system.url-prefix': 'http://example.com'}):
+            self.plugin.notify(notification)
+
+        request = responses.calls[0].request
+        payload = json.loads(parse_qs(request.body)['payload'][0])
+        assert payload == {
+            'channel': '#test_channel',
+            'parse': 'none',
+            'username': 'Sentry',
+            'attachments': [
+                {
+                    'color': '#f43f20',
+                    'fields': [
+                        {
+                            'short': False,
+                            'value': 'foo.bar',
+                            'title': 'Culprit',
+                        },
+                        {
+                            'short': True,
+                            'value': 'foo Bar',
+                            'title': 'Project'
+                        },
+                    ],
+                    'fallback': '[foo Bar] Hello world',
+                    'title': 'Hello world',
+                    'title_link': 'http://example.com/baz/bar/issues/1/',
+                },
+            ],
+        }
+
+        request = responses.calls[1].request
+        payload = json.loads(parse_qs(request.body)['payload'][0])
+        assert payload == {
+            'channel': '#test_channel2',
+            'parse': 'none',
+            'username': 'Sentry',
+            'attachments': [
+                {
+                    'color': '#f43f20',
+                    'fields': [
+                        {
+                            'short': False,
+                            'value': 'foo.bar',
+                            'title': 'Culprit',
+                        },
+                        {
+                            'short': True,
+                            'value': 'foo Bar',
+                            'title': 'Project'
+                        },
+                    ],
+                    'fallback': '[foo Bar] Hello world',
+                    'title': 'Hello world',
+                    'title_link': 'http://example.com/baz/bar/issues/1/',
+                },
+            ],
+        }


### PR DESCRIPTION
This is something we required to send events coming from different portions of the same application to the right team in slack.

Provides configuration so that a specific tag can be used to direct the events to the right channel depending on that tag's value.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-slack/43)

<!-- Reviewable:end -->
