### PR TITLE
Add configuration option to suppress project name.

### DIFF
--- a/src/sentry_slack/plugin.py
+++ b/src/sentry_slack/plugin.py
@@ -62,6 +62,10 @@ class SlackOptionsForm(notify.NotificationConfigurationForm):
         }),
         required=False
     )
+    suppress_project_name = forms.BooleanField(
+        help_text='Do not display project name in notification',
+        required=False,
+    )
     include_tags = forms.BooleanField(
         help_text='Include tags with notifications',
         required=False,
@@ -166,11 +170,12 @@ class SlackPlugin(notify.NotificationPlugin):
                 'short': False,
             })
 
-        fields.append({
-            'title': 'Project',
-            'value': project_name,
-            'short': True,
-        })
+        if not self.get_option('suppress_project_name', project):
+            fields.append({
+                'title': 'Project',
+                'value': project_name,
+                'short': True,
+            })
 
         if self.get_option('include_rules', project):
             rules = []


### PR DESCRIPTION
All of our project notifications are sent into separate Slack channels
making the addition of the project name redundant in the notification.
This patch adds a configuration option to suppress the project name from
the notification.

fixes #44

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/sentry-slack/53)

<!-- Reviewable:end -->
