### PR TITLE
Add a workaround for TagKey, TagValue import error

### DIFF
--- a/src/sentry_slack/plugin.py
+++ b/src/sentry_slack/plugin.py
@@ -13,7 +13,10 @@ from django.core.urlresolvers import reverse
 from django.db.models import Q
 
 from sentry import http
-from sentry.models import TagKey, TagValue
+try:
+    from sentry.models import TagKey, TagValue
+except ImportError:
+    from sentry.tagstore.legacy.models import TagKey, TagValue
 from sentry.plugins.bases import notify
 from sentry.utils import json
 from sentry.utils.http import absolute_uri


### PR DESCRIPTION
TagKey and TagValue classes have been moved to legacy in new versions of Sentry (8.22.0 at least). It gives an import error. This simple fix helps until sentry-slack will be updated by an author.